### PR TITLE
update powershell scripts to handle clearing text on the display

### DIFF
--- a/powershell/2012_ad_preparation.ps1
+++ b/powershell/2012_ad_preparation.ps1
@@ -22,7 +22,12 @@ Windows 2012 R2
 
 Import-Module ServerManager -passthru
 
-Clear-Host
+try {
+    Clear-Host
+} catch {
+    Write-Host "No text to remove from current display."
+}
+
 Remove-Variable -Name * -Force -ErrorAction SilentlyContinue
 
 $scriptName = $MyInvocation.MyCommand.Name

--- a/powershell/2012_ad_setup_step1.ps1
+++ b/powershell/2012_ad_setup_step1.ps1
@@ -28,7 +28,12 @@ Windows 2012 R2
 
 Import-Module ServerManager -passthru
 
-Clear-Host
+try {
+    Clear-Host
+} catch {
+    Write-Host "No text to remove from current display."
+}
+
 Remove-Variable -Name * -Force -ErrorAction SilentlyContinue
 
 $scriptName = $MyInvocation.MyCommand.Name

--- a/powershell/2012_ad_setup_step2.ps1
+++ b/powershell/2012_ad_setup_step2.ps1
@@ -22,7 +22,12 @@ Windows 2012 R2
 
 Import-Module ServerManager -passthru
 
-Clear-Host
+try {
+    Clear-Host
+} catch {
+    Write-Host "No text to remove from current display."
+}
+
 Remove-Variable -Name * -Force -ErrorAction SilentlyContinue
 
 $scriptName = $MyInvocation.MyCommand.Name

--- a/powershell/2016_ad_preparation.ps1
+++ b/powershell/2016_ad_preparation.ps1
@@ -24,7 +24,12 @@ win-2016-serverstandard-x86_64-latest-pretest
 
 Import-Module ServerManager -passthru
 
-Clear-Host
+try {
+    Clear-Host
+} catch {
+    Write-Host "No text to remove from current display."
+}
+
 Remove-Variable -Name * -Force -ErrorAction SilentlyContinue
 
 $scriptName = $MyInvocation.MyCommand.Name

--- a/powershell/2016_ad_setup_step1.ps1
+++ b/powershell/2016_ad_setup_step1.ps1
@@ -31,7 +31,12 @@ win-2016-serverstandard-x86_64-latest-pretest
 
 Import-Module ServerManager -passthru
 
-Clear-Host
+try {
+    Clear-Host
+} catch {
+    Write-Host "No text to remove from current display."
+}
+
 Remove-Variable -Name * -Force -ErrorAction SilentlyContinue
 
 $scriptName = $MyInvocation.MyCommand.Name

--- a/powershell/2016_ad_setup_step2.ps1
+++ b/powershell/2016_ad_setup_step2.ps1
@@ -25,7 +25,12 @@ win-2016-serverstandard-x86_64-latest-pretest
 
 Import-Module ServerManager -passthru
 
-Clear-Host
+try {
+    Clear-Host
+} catch {
+    Write-Host "No text to remove from current display."
+}
+
 Remove-Variable -Name * -Force -ErrorAction SilentlyContinue
 
 $scriptName = $MyInvocation.MyCommand.Name

--- a/powershell/administrator_password.ps1
+++ b/powershell/administrator_password.ps1
@@ -19,7 +19,12 @@ Windows 2012 R2
     Eduardo Cerqueira, eduardomcerqueira@gmail.com
 #>
 
-﻿Clear-Host
+try {
+    Clear-Host
+} catch {
+    Write-Host "No text to remove from current display."
+}
+
 Remove-Variable -Name * -Force -ErrorAction SilentlyContinue
 
 $scriptName = $MyInvocation.MyCommand.Name

--- a/powershell/chocolatey.ps1
+++ b/powershell/chocolatey.ps1
@@ -34,7 +34,11 @@ param(
     [Parameter(Mandatory=$True)][array]$packages
 )
 
-Clear-Host
+try {
+    Clear-Host
+} catch {
+    Write-Host "No text to remove from current display."
+}
 
 $scriptName = $MyInvocation.MyCommand.Name
 $log = "$(get-date) - $scriptName"

--- a/powershell/cmd.ps1
+++ b/powershell/cmd.ps1
@@ -35,7 +35,11 @@ param(`
     [Parameter(Mandatory=$True)][string]$cmd
 )
 
-Clear-Host
+try {
+    Clear-Host
+} catch {
+    Write-Host "No text to remove from current display."
+}
 
 $scriptName = $MyInvocation.MyCommand.Name
 $log = "$(get-date) - $scriptName"

--- a/powershell/get_screen_resolution.ps1
+++ b/powershell/get_screen_resolution.ps1
@@ -22,7 +22,11 @@ Eduardo Cerqueira <eduardomcerqueira@gmail.com>
 
 #>
 
-Clear-Host
+try {
+    Clear-Host
+} catch {
+    Write-Host "No text to remove from current display."
+}
 
 $scriptName = $MyInvocation.MyCommand.Name
 $log = "$(get-date) - $scriptName"

--- a/powershell/get_system_info.ps1
+++ b/powershell/get_system_info.ps1
@@ -16,7 +16,12 @@ Windows 2012 R2
     Eduardo Cerqueira, eduardomcerqueira@gmail.com
 #>
 
-Clear-Host
+try {
+    Clear-Host
+} catch {
+    Write-Host "No text to remove from current display."
+}
+
 Remove-Variable -Name * -Force -ErrorAction SilentlyContinue
 
 $scriptName = $MyInvocation.MyCommand.Name

--- a/powershell/install_chocolatey.ps1
+++ b/powershell/install_chocolatey.ps1
@@ -19,7 +19,11 @@ Windows Server 2012 R2
 Ryan Williams <rwilliams5262@gmail.com>
 #>
 
-Clear-Host
+try {
+    Clear-Host
+} catch {
+    Write-Host "No text to remove from current display."
+}
 
 $scriptName = $MyInvocation.MyCommand.Name
 $log = "$(get-date) - $scriptName"

--- a/powershell/jslave_add_service.ps1
+++ b/powershell/jslave_add_service.ps1
@@ -62,7 +62,11 @@ param(
     [Parameter(Mandatory=$False)][array]$password
 )
 
-Clear-Host
+try {
+    Clear-Host
+} catch {
+    Write-Host "No text to remove from current display."
+}
 
 $scriptName = $MyInvocation.MyCommand.Name
 $log = "$(get-date) - $scriptName"

--- a/powershell/jslave_get_swarm_client.ps1
+++ b/powershell/jslave_get_swarm_client.ps1
@@ -32,7 +32,11 @@ param(
     [Parameter(Mandatory=$True)][array]$fsroot_path
 )
 
-Clear-Host
+try {
+    Clear-Host
+} catch {
+    Write-Host "No text to remove from current display."
+}
 
 $scriptName = $MyInvocation.MyCommand.Name
 $log = "$(get-date) - $scriptName"

--- a/powershell/nssm_manage.ps1
+++ b/powershell/nssm_manage.ps1
@@ -27,7 +27,11 @@ param(`
     [Parameter(Mandatory=$True)][string]$service_name
 )
 
-Clear-Host
+try {
+    Clear-Host
+} catch {
+    Write-Host "No text to remove from current display."
+}
 
 $scriptName = $MyInvocation.MyCommand.Name
 $log = "$(get-date) - $scriptName"

--- a/powershell/reboot.ps1
+++ b/powershell/reboot.ps1
@@ -21,7 +21,12 @@ Windows 2012 R2
 
 Import-Module ServerManager -passthru
 
-Clear-Host
+try {
+    Clear-Host
+} catch {
+    Write-Host "No text to remove from current display."
+}
+
 Remove-Variable -Name * -Force -ErrorAction SilentlyContinue
 
 $scriptName = $MyInvocation.MyCommand.Name

--- a/powershell/rename_computer.ps1
+++ b/powershell/rename_computer.ps1
@@ -20,7 +20,12 @@ Windows 2012 R2
     Eduardo Cerqueira, eduardomcerqueira@gmail.com
 #>
 
-Clear-Host
+try {
+    Clear-Host
+} catch {
+    Write-Host "No text to remove from current display."
+}
+
 Remove-Variable -Name * -Force -ErrorAction SilentlyContinue
 
 $scriptName = $MyInvocation.MyCommand.Name

--- a/powershell/set_env_var.ps1
+++ b/powershell/set_env_var.ps1
@@ -40,7 +40,11 @@ param(`
     [Parameter(Mandatory=$False)][array]$levels
 )
 
-Clear-Host
+try {
+    Clear-Host
+} catch {
+    Write-Host "No text to remove from current display."
+}
 
 $scriptName = $MyInvocation.MyCommand.Name
 $log = "$(get-date) - $scriptName"

--- a/powershell/set_screen_resolution.ps1
+++ b/powershell/set_screen_resolution.ps1
@@ -28,7 +28,11 @@ param(`
     [Parameter(Mandatory=$True)][string]$height
 )
 
-Clear-Host
+try {
+    Clear-Host
+} catch {
+    Write-Host "No text to remove from current display."
+}
 
 $scriptName = $MyInvocation.MyCommand.Name
 $log = "$(get-date) - $scriptName"

--- a/powershell/set_uac.ps1
+++ b/powershell/set_uac.ps1
@@ -33,7 +33,11 @@ Ryan Williams <rwilliams5262@gmail.com>
 
 param([Parameter(Mandatory=$True)][int]$uacValue)
 
-Clear-Host
+try {
+    Clear-Host
+} catch {
+    Write-Host "No text to remove from current display."
+}
 
 $scriptName = $MyInvocation.MyCommand.Name
 $log = "$(get-date) - $scriptName"


### PR DESCRIPTION
This commit updates all powershell scripts to make them fully compatible
with ansible >= 2.5. The latest release was causing ansible script
module to return a non 0 return code. Exceptions were being raised
when attempting to call the function `Clear-Host` when no text was
displayed on the screen. A try catch code block has been added to
resolve this issue.